### PR TITLE
Fix for instagram links

### DIFF
--- a/components/instagramFeed.js
+++ b/components/instagramFeed.js
@@ -5,7 +5,7 @@ export default function InstagramFeed({ posts }) {
 				return (
 					<li>
 						<a
-							href={`https://www.instagram.com/p/${post.id}`}
+							href={post.permalink}
 							key={i}
 							aria-label="view image on Instagram"
 						>

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,7 +46,7 @@ export async function getStaticProps() {
   }
 
   const token = data.Token;
-  const instaRes = await fetch(`https://graph.instagram.com/me/media?fields=id,media_url,caption&access_token=${token}`);
+  const instaRes = await fetch(`https://graph.instagram.com/me/media?fields=media_url,caption,permalink&access_token=${token}`);
   const instaData = await instaRes.json();
   const instaPosts = instaData.data;
 


### PR DESCRIPTION
Fix for the hyperlinks to the instagram post.  Changed to use permalink rather than ID.